### PR TITLE
解决查询时间类型为null时引发空指针调用函数奔溃问题

### DIFF
--- a/sql/rows.go
+++ b/sql/rows.go
@@ -76,7 +76,7 @@ func (this *Rows) parse(value reflect.Value, index int, fields []interface{}) er
 			if value.Type().String() == "time.Time" {
 				//时间结构体解析
 				var v = *(fields[index].(*interface{}))
-				if reflect.TypeOf(v).String() == "time.Time" {
+				if v != nil && reflect.TypeOf(v).String() == "time.Time" {
 					value.Set(reflect.ValueOf(v))
 				} else {
 					var s = sql.NullString{}


### PR DESCRIPTION
修复了https://github.com/kdada/tinygo/issues/6